### PR TITLE
Add support for hqThumbnail

### DIFF
--- a/src/lib/structures/Track.ts
+++ b/src/lib/structures/Track.ts
@@ -39,6 +39,7 @@ export interface ITrack {
     readonly title: string;
     readonly uri: string;
     readonly thumbnail: string;
+    readonly hqThumbnail: string;
     readonly requester: User;
 }
 
@@ -58,6 +59,7 @@ export class Track implements ITrack {
     public title: string;
     public uri: string;
     public thumbnail: string;
+    public hqThumbnail: string;
     public requester: User;
     /**
      * Creates an instance of Track.
@@ -81,6 +83,8 @@ export class Track implements ITrack {
             this.uri = data.info.uri;
             this.thumbnail = this.uri.includes("youtube") ?
                 `https://img.youtube.com/vi/${this.identifier}/default.jpg` : "";
+            this.hqThumbnail = this.uri.includes("youtube") ?
+                `https://img.youtube.com/vi/${this.identifier}/hqdefault.jpg` : "";
             this.requester = user;
         } catch (err) {
             throw new RangeError(`Invalid track passed. Reason: ${err}`);


### PR DESCRIPTION
It would be nice to be able to get the hqdefault thumbnail for a track. If you doesn't want to merge this PR because you don't want to add a new property to the Track class (if you do, we will have to add `track.sddefaultThumbnail`), maybe this could be interesting:
```js
track.displayThumbnail("hqdefault");
track.displayThumbnail("default");
track.displayThumbnail("sddefault");
// etc...
```
Because actually I have to do:
```js
.setImage(res.playlist.tracks[0].thumbnail.replace("default", "hqdefault"));
```