### PR TITLE
fix: Reduce of empty array with no initial value

### DIFF
--- a/src/lib/entities/Queue.ts
+++ b/src/lib/entities/Queue.ts
@@ -11,7 +11,7 @@ export class Queue extends Array {
      * @returns {number} - The duration of the queue.
      */
     public get duration(): number {
-        return this.map((track: Track) => track.duration).reduce((acc: number, cur: number) => acc + cur);
+        return this.map((track: Track) => track.duration).reduce((acc: number, cur: number) => acc + cur, 0);
     }
 
     /**

--- a/src/lib/entities/SearchResult.ts
+++ b/src/lib/entities/SearchResult.ts
@@ -89,7 +89,7 @@ export class SearchResult {
         this.playlist = {
             info: data.playlistInfo,
             tracks: this.loadType === "PLAYLIST_LOADED" ? data.tracks.map((d) => new track(d, user)) : [],
-            duration: this.tracks.map((t) => t.duration).reduce((acc: number, cur: number) => acc + cur),
+            duration: this.tracks.map((t) => t.duration).reduce((acc: number, cur: number) => acc + cur, 0),
         };
 
         if (data.exception) {


### PR DESCRIPTION
Fixes `TypeError: Reduce of empty array with no initial value`,
Why does this happen ? its because reduce works like that , the syntax of reduce is 
![image](https://user-images.githubusercontent.com/38991749/76105840-c123cb80-5ffb-11ea-80d2-b9097dbacc8a.png)
Now the issue is in the second parameter of the `Array.prototype.reduce`, it doesn't have a initial value to being with which could lead to a error Reduce of empty array with no initial value as the docs says it.
![image](https://user-images.githubusercontent.com/38991749/76105977-fb8d6880-5ffb-11ea-8ebd-0b75f836eb6a.png)

This pr fixes all those issues. 