### PR TITLE
Fix issue where "trackEnd" wouldn't get emitted, and a bug in the trackStuck and trackError events

### DIFF
--- a/src/structures/Node.ts
+++ b/src/structures/Node.ts
@@ -242,6 +242,7 @@ export class Node {
         } else if (!player.queue.length) {
             player.current = null;
             player.playing = false;
+            this.manager.emit("trackEnd", player, track, payload);
             if (["REPLACED", "FINISHED", "STOPPED"].includes(payload.reason)) {
                 this.manager.emit("queueEnd", player);
             }
@@ -259,12 +260,12 @@ export class Node {
     }
 
     protected trackStuck(player: Player, track: Track, payload: any): void {
-        player.queue.shift();
+        player.stop();
         this.manager.emit("trackStuck", player, track, payload);
     }
 
     protected trackError(player: Player, track: Track, payload: any): void {
-        player.queue.shift();
+        player.stop();
         this.manager.emit("trackError", player, track, payload);
     }
 


### PR DESCRIPTION
When a track ends, and if Player#queue is empty, Erela wouldn't emit the "trackEnd" event, as it was missing `this.manager.emit("trackEnd", player, track, payload);`.

Also, if track got stuck or a track error was encountered, instead of removing the current track that has errored out with `player.stop();` and continue with playing the next track in the queue,  Erela would remove incorrectly remove the first track in the queue with `player.queue.shift();`. This was because the current track was swapped to Player#current in the rewrite, and in previous versions of Erela, the current track would just be the first element in Player#queue.